### PR TITLE
Add explicit instructions for measure.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Installation
 1. [Download the ZIP file with the Measure](https://github.com/utom/sketch-measure/archive/master.zip)
 2. Copy the contents of the ZIP to the Plugins Folder (You can get access to that folder by opening the Plugins menu, choosing "Custom Script..." and then clicking in the gear icon and choosing "Open Plugins Folder")
 ![Path](http://file.is26.com/wp-image/2014/04/sketch-measure-path.png)
+3. Make sure to that `measure.js` is placed within `Plugins/library` if you already have that directory. If not, just copy the `library` directory from the unzipped folder.
+![Measure](http://f.cl.ly/items/241W02313j2t1N3n1E3H/Screen%20Shot%202014-04-03%20at%201.05.17%20PM.png)
+
 
 How-to
 ------


### PR DESCRIPTION
I already had a `library` directory so I thought it'd be useful to make its use clear.
