### PR TITLE
Beta 3.2 fix

### DIFF
--- a/library/common.js
+++ b/library/common.js
@@ -77,7 +77,7 @@ function setColor(layer, hex, alpha) {
     [layer setTextColor: color];
   }
   else if( isShape(layer) ) {
-    if (is(layer, 'MSRectangleShape')) {
+    if (is(layer, MSRectangleShape)) {
       layer = [layer embedInShapeGroup];
     }
 


### PR DESCRIPTION
This addresses #26.

It would seem that rectangles added in 3.2 generate a MSRectangleShape and not a MSShapeGroup. MSRectangleShape objects don't have a style (and therefore no fill) and must first be embedded in a shape group, so it would seem. I've added some logic here to be backwards compatible.

If someone has a better grasp of what's happening here please dive right in.
