### PR TITLE
Add option for Points @1x (pt) resolution

### DIFF
--- a/6. Settings/2. Design Resolution.sketchplugin
+++ b/6. Settings/2. Design Resolution.sketchplugin
@@ -3,15 +3,16 @@
 
 var alert = createAlertBase(),
     types = [
-    	'LDPI @0.75x (dp)',
-    	'MDPI @1x (dp)',
-    	'HDPI @1.5x (dp)',
-    	'XHDPI @2x (dp)',
-    	'XXHDPI @3x (dp)',
-    	'XXXHDPI @4x (dp)',
-    	'Standard @1x (px)',
-    	'Retina @2x (pt)',
-    	'Retina HD @3x (pt)'
+      'LDPI @0.75x (dp)',
+      'MDPI @1x (dp)',
+      'HDPI @1.5x (dp)',
+      'XHDPI @2x (dp)',
+      'XXHDPI @3x (dp)',
+      'XXXHDPI @4x (dp)',
+      'Standard @1x (px)',
+        'Points @1x (pt)',
+      'Retina @2x (pt)',
+      'Retina HD @3x (pt)'
     ],
     index = getIndex(types, configs.resolution);
 

--- a/library/common.js
+++ b/library/common.js
@@ -12,6 +12,7 @@ var page = [doc currentPage],
         'XXHDPI @3x (dp)': 3,
        'XXXHDPI @4x (dp)': 4,
       'Standard @1x (px)': 1,
+       'Points @1x (pt)' : 1,
         'Retina @2x (pt)': 2,
      'Retina HD @3x (pt)': 3
   };


### PR DESCRIPTION
For those who design at 1x and want their units in pts.

New resolution:

```
Points @1x (pt)
```


Reference - I design most everything at 1x resolution. Currently I have to use the 'Standard @1x (px)' design resolution. When handing mocks to devs, I want my 1x resolution artboards to use points for measuring. 

![image](https://cloud.githubusercontent.com/assets/56019/7594405/4281f0cc-f895-11e4-8133-9c2606335888.png)
