### PR TITLE
Sketch 3.5 support

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -220,7 +220,7 @@ com.utom.extend({
         var layerStyles = this.document.documentData().layerStyles();
         var layerStylesLibrary = layerStyles.objectsSortedByName();
         var layerStyle = this.find(name, layerStylesLibrary, true);
-        layerStyle = ( !layerStyle || this.is(layerStyle, MSSharedLayerStyle))? layerStyle: layerStyle[0];
+        layerStyle = layerStyle;
         var alpha = alpha || 1;
 
         if( layerStyle == false ){
@@ -253,7 +253,7 @@ com.utom.extend({
         var textStyles = this.document.documentData().layerTextStyles();
         var textStylesLibrary = textStyles.objectsSortedByName();
         var textStyle = this.find(name, textStylesLibrary, true);
-        textStyle = (!textStyle || this.is(textStyle, MSSharedLayerStyle))? textStyle: textStyle[0];
+        textStyle = textStyle;
         var alpha = alpha || 1;
 
         if( textStyle == false ){


### PR DESCRIPTION
Removed MSSharedLayerStyle dependency for now, since that no longer works under sketch 3.5
Might need another iteration to re-establish shared layer style behavior but at least plugin works again.