### PR TITLE
modified rem scale to be 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Sketch Measure.sketchplugin/Contents/Sketch/assets/app.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/assets/app.js
@@ -47,7 +47,7 @@
       3,   //  8: XXHDPI @3x (dp, sp)
       4,   //  9: XXXHDPI @4x (dp, sp)
       27,  // 10: Ubuntu Grid Units (27px)
-      14,  // 11: CSS Rem (14px)
+      16,  // 11: CSS Rem (16px)
     ],
     ResolutionName = [
       "Standard",                    // 0
@@ -61,7 +61,7 @@
       "XXHDPI @3x (dp, sp)",             // 8
       "XXXHDPI @4x (dp, sp)",            // 9
       "Ubuntu Grid (27px)",    // 10
-      "CSS Rem (14px)",              // 11
+      "CSS Rem (16px)",              // 11
     ],
     ColorFormat = [
         "Color Hex",

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -171,7 +171,7 @@ com.utom.extend({
           unit = "gu";
         }
 
-        if (scale === 14) {
+        if (scale === 16) {
           unit = "rem";
         }
 
@@ -395,8 +395,8 @@ com.utom.extend({
             scale: 27
         },
         {
-            name: "CSS Rem (14px)",
-            scale: 14
+            name: "CSS Rem (16px)",
+            scale: 16
         },
     ],
     resolutionSetting: function(){


### PR DESCRIPTION
It appears that most browsers default to using 16px as a base scale for rem units. Haven't encountered a 14px scale in the wild yet so this should help out all the folk out there using rems.

