### PR TITLE
Display defaultLineHeight when it's used.

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/assets/app.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/assets/app.js
@@ -475,7 +475,7 @@
                 jQTypeface.show().find("ul").append(
                     self.template($("#type-template"), {
                         size:self.resolutionSize(model.fontSize, true),
-                        line:self.resolutionSize(model.lineHeight, true),
+                        line:self.resolutionSize(model.lineHeight === 0 ? model.baseLineHeight : model.lineHeight, true),
                         character:self.resolutionSize(model.letterSpacing, true),
                         face:model.fontFace
                     })

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -2491,6 +2491,7 @@ com.utom.extend({
                     layer.textAlign = this.TextAligns[msLayer.textAlignment()];
                     layer.letterSpacing = msLayer.characterSpacing();
                     layer.lineHeight = msLayer.lineHeight();
+                    layer.baseLineHeight = msLayer.baseLineHeight();
                 }
 
 

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -2489,7 +2489,9 @@ com.utom.extend({
                     layer.fontSize = msLayer.fontSize();
                     layer.fontFace = this.toJSString(msLayer.fontPostscriptName());
                     layer.textAlign = this.TextAligns[msLayer.textAlignment()];
-                    layer.letterSpacing = msLayer.characterSpacing();
+                    var characterSpacing = msLayer.characterSpacing();
+                    var spacingFloatValue = [characterSpacing floatValue]; // get float value from NSNumber
+                    layer.letterSpacing = spacingFloatValue;
                     layer.lineHeight = msLayer.lineHeight();
                     layer.baseLineHeight = msLayer.baseLineHeight();
                 }


### PR DESCRIPTION
When lineHeight equals zero, Sketchapp uses the defaultLineHeight instead. This isn't currently reflected in the Measure spec export. This branch displays the text layer defaultLineHeight when lineHeight equals zero.