### PR TITLE
Fixed spec value character spacing "NaN"

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -2489,7 +2489,13 @@ com.utom.extend({
                     layer.fontSize = msLayer.fontSize();
                     layer.fontFace = this.toJSString(msLayer.fontPostscriptName());
                     layer.textAlign = this.TextAligns[msLayer.textAlignment()];
-                    layer.letterSpacing = msLayer.characterSpacing();
+                    if(msLayer.characterSpacing() !== null){
+                        var characterSpacing = msLayer.characterSpacing();
+                        var spacingFloatValue = [characterSpacing floatValue]; // get float value from NSNumber
+                        layer.letterSpacing = spacingFloatValue;
+                    } else {
+                        layer.letterSpacing = 0;
+                    }
                     layer.lineHeight = msLayer.lineHeight();
                 }
 


### PR DESCRIPTION
msLayer.characterSpacing() can't be used directly as a value, the floatValue getter must be used instead.

This fixes the "NaN" that appears for the character spacing value in spec export.

Update: added conditional to check for null NSNumber.