### PR TITLE
[spec export] Change zoom-in range to 25%-400%

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/assets/app.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/assets/app.js
@@ -684,8 +684,8 @@
                 delay = delay || 0;
             jQZoom.find(".zoom-text").text(self.zoom * 100 + "%");
             jQZoom.find(".disable").removeClass("disable");
-            if (self.zoom <= .5) jQZoom.find(".zoom-out").addClass("disable");
-            if (self.zoom >= 1) jQZoom.find(".zoom-in").addClass("disable");
+            if (self.zoom <= .25) jQZoom.find(".zoom-out").addClass("disable");
+            if (self.zoom >= 4) jQZoom.find(".zoom-in").addClass("disable");
             self.screen();
             self.layers(index, delay);
             self.resolutionList();
@@ -812,16 +812,26 @@
                     $(".dropdown").addClass("hide");
                 })
                 .on("click", ".zoom-out", function(event) {
-                    self.zoom -= .25;
                     if (self.zoom <= .25) {
-                        self.zoom = .5;
+                        self.zoom = .25;
+                    } else if (self.zoom <= 1) {
+                        self.zoom -= .25;
+                    } else if (self.zoom <= 2) {
+                        self.zoom -= .5;
+                    } else {
+                        self.zoom -= 1;
                     }
                     self.render(self.index(), 300);
                 })
                 .on("click", ".zoom-in", function(event) {
-                    self.zoom += .25;
-                    if (self.zoom >= 1) {
-                        self.zoom = 1;
+                    if (self.zoom >= 4) {
+                        self.zoom = 4;
+                    } else if (self.zoom >= 2) {
+                        self.zoom += 1;
+                    } else if (self.zoom >= 1) {
+                        self.zoom += .5;
+                    } else {
+                        self.zoom += .25;
                     }
                     self.render(self.index(), 300);
                 });

--- a/Sketch Measure.sketchplugin/Contents/Sketch/manifest.json
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/manifest.json
@@ -151,7 +151,7 @@
         "title" : "Measure"
     },
     "identifier": "com.utom.sketch-measure",
-    "version": "0.9.4.6",
+    "version": "0.9.4.7",
     "description" : "A measure tool for measurements & design specs.",
     "authorEmail" : "utombox@gmail.com",
     "name" : "Sketch Measure"


### PR DESCRIPTION
It's very useful to be able to zoom in closer in the spec export without having to resort to using the browser zoom function.

This change enables zooming from 25% up to 400% in spec export by changing the scale caps. Also tweaked the zoom-in increment when zooming above to make it more natural.

Disregard this proposed change if there is some deeper reason for capping the zoom where it was, but still consider finding a way to raise it to at least 200%. 100% seems very low and I'm in favor of letting the user zoom as much or as little as they want.