### PR TITLE
A solution for Issue #260

### DIFF
--- a/HOW-TO.md
+++ b/HOW-TO.md
@@ -1,6 +1,6 @@
 ## Installing Plugins
 
-1. [Download the ZIP file with the Measure](https://github.com/utom/sketch-measure/archive/master.zip) and unzip;
+1. [Download the ZIP file with the Measure](https://github.com/forestlin1212/sketch-measure/archive/master.zip) and unzip;
 2. Open the `Sketch Measure.sketchplugin`;
 
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # A new feature for Sketch Measure: Export Layer's influence Rect to Spec.
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
+              Regular rect              Influence rect
+![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987287898_400x400big.png)
+![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987158747_400x399big.png)
 
-![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg14875992091129_300x300big.png)
-![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg14875992091129_300x300big.png)
+Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for. 
+Just the option in Export UI
 
-Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for.
-
+![export-ui](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759897429137_471x602big.png)
 
 # Sketch Measure
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Add new feature to Sketch Measure: Export Layer's influence Rect to Spec.
+
 # Sketch Measure
 
 Make it fun to create specs for developers and teammates. **Sketch 41.* support**.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,10 @@ Make it fun to create specs for developers and teammates. **Sketch 41.* support*
 - [How to](http://utom.design/measure/how-to.html)
 - [中文说明](http://sketch.im/plugins/1)
 
-#### [Sponsor me to buy a new iPhone](http://utom.design/measure/donate.html)
-
 ![Logo](http://utom.design/logo@2x.png)
 
 ## Installing Plugins
-1. [Download the ZIP file](https://github.com/utom/sketch-measure/archive/master.zip) and unzip
+1. [Download the ZIP file](https://github.com/forestlin1212/sketch-measure/archive/master.zip) and unzip
 2. Open `Sketch Measure.sketchplugin`
 
 ## New UI

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
-![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759784688425_1138x1140.png)
+![regular-rect](http://wx1.sinaimg.cn/large/86f4266dgy1fcx9th2urvj20d30gqmyj.jpg)
 
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for.
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
-              Regular rect              Influence rect
+                                      Regular rect                                                                       Influence rect
               
 ![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987287898_400x400big.png)
 ![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987158747_400x399big.png)
 
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for. 
 
-Just the option in Export UI
+Just select the option in Export UI
 
 ![export-ui](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759897429137_471x602big.png)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Add new feature to Sketch Measure: Export Layer's influence Rect to Spec.
+# A new feature for Sketch Measure: Export Layer's influence Rect to Spec.
+
+Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
+
+Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for.
+
 
 # Sketch Measure
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
-![regular-rect](http://wx1.sinaimg.cn/large/86f4266dgy1fcx9th2urvj20d30gqmyj.jpg)
+![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759784688425_1138x1140.png)
+![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759784458139_1140x1140.png)
 
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Layer's influence rect includes the area of shadows and outside borders, it's ex
 ![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987287898_400x400big.png)
 ![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987158747_400x399big.png)
 
-Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for. 
+Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect to engineers, not the regular rect. This is the feature using for. 
 
 Just select the option in Export UI
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Layer's influence rect includes the area of shadows and outside borders, it's ex
 
                                       Regular rect                                                                       Influence rect
               
-![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987287898_400x400big.png)
-![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987158747_400x399big.png)
+![regular-rect](https://pic4.zhimg.com/v2-c1792b8300fca0cdc90b564a27b8da8b_b.png)
+![influence-rect](https://pic3.zhimg.com/v2-a639e906f8fea576da8d9a8cc1cc752a_b.png)
 
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect to engineers, not the regular rect. This is the feature using for. 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
+![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759784688425_1138x1140.png)
+
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for.
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
-                          Regular rect                                                      Influence rect
+                                       Regular rect                                                           Influence rect
               
 ![regular-rect](https://pic4.zhimg.com/v2-c1792b8300fca0cdc90b564a27b8da8b_b.png)
 ![influence-rect](https://pic3.zhimg.com/v2-a639e906f8fea576da8d9a8cc1cc752a_b.png)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
-![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759897674324_600x601.png)
-![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759897548900_600x600.png)
+![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg14875992091129_300x300big.png)
+![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg14875992091129_300x300big.png)
 
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
-![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759784688425_1138x1140.png)
-![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759784458139_1140x1140.png)
+![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759897674324_600x601.png)
+![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759897548900_600x600.png)
 
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # A new feature for Sketch Measure: Export Layer's influence Rect to Spec.
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
+
               Regular rect              Influence rect
+              
 ![regular-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987287898_400x400big.png)
 ![influence-rect](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759987158747_400x399big.png)
 
 Sometime, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect in for engineers, not the regular rect. This is the feature using for. 
+
 Just the option in Export UI
 
 ![export-ui](https://i1.hoopchina.com.cn/blogfile/201702/20/BbsImg148759897429137_471x602big.png)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image.
 
-                                      Regular rect                                                                       Influence rect
+                          Regular rect                                                      Influence rect
               
 ![regular-rect](https://pic4.zhimg.com/v2-c1792b8300fca0cdc90b564a27b8da8b_b.png)
 ![influence-rect](https://pic3.zhimg.com/v2-a639e906f8fea576da8d9a8cc1cc752a_b.png)

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -3125,11 +3125,28 @@ SM.extend({
             layer.setTextBehaviour(0); // fixed for v40
         } // fixed for v40
 
+        var exportLayerRect;
+        
+        if(true){
+            // export the influence rect.(include the area of shadows and outside borders...)
+            var influenceCGRect = layer.absoluteInfluenceRect();
+            exportLayerRect = {
+                        x: function(){return influenceCGRect.origin.x;},
+                        y: function(){return influenceCGRect.origin.y;},
+                        width: function(){return influenceCGRect.size.width;},
+                        height: function(){return influenceCGRect.size.height;}
+            }
+        }
+        else{
+            // export the default rect.
+            exportLayerRect = layer.absoluteRect();
+        }
+        
         var layerData = {
                     objectID: this.toJSString( layer.objectID() ),
                     type: layerType,
                     name: this.toHTMLEncode(this.emojiToEntities(layer.name())),
-                    rect: this.rectToJSON(layer.absoluteRect(), artboardRect)
+                    rect: this.rectToJSON(exportLayerRect, artboardRect)
                 };
 
         if(symbolLayer) layerData.objectID = this.toJSString( symbolLayer.objectID() );

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -3126,8 +3126,7 @@ SM.extend({
         } // fixed for v40
 
         var exportLayerRect;
-        
-        if(true){
+        if(true && layerType != "text"){
             // export the influence rect.(include the area of shadows and outside borders...)
             var influenceCGRect = layer.absoluteInfluenceRect();
             exportLayerRect = {

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -2790,6 +2790,11 @@ SM.extend({
             data.exportOption = true;
         }
 
+        data.exportInfluenceRect = self.configs.exportInfluenceRect;
+        if(data.exportInfluenceRect == undefined){
+            data.exportInfluenceRect = false;
+        }
+
         self.configs.order = (self.configs.order)? self.configs.order: "positive";
         data.order = self.configs.order;
 
@@ -2868,6 +2873,7 @@ SM.extend({
 
                 self.configs = self.setConfigs({
                     exportOption: data.exportOption,
+                    exportInfluenceRect: data.exportInfluenceRect,
                     order: data.order
                 });
             }
@@ -3126,7 +3132,8 @@ SM.extend({
         } // fixed for v40
 
         var exportLayerRect;
-        if(true && layerType != "text"){
+        log(this.configs);
+        if(this.configs.exportInfluenceRect == true && layerType != "text"){
             // export the influence rect.(include the area of shadows and outside borders...)
             var influenceCGRect = layer.absoluteInfluenceRect();
             exportLayerRect = {

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -2830,7 +2830,7 @@ SM.extend({
         return this.SMPanel({
             url: this.pluginSketch + "/panel/export.html",
             width: 320,
-            height: 567,
+            height: 577,
             data: data,
             callback: function( data ){
                 var allData = self.allData;

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/i18n/zh-Hans.json
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/i18n/zh-Hans.json
@@ -89,6 +89,7 @@
     "Import complete!": "导入完成!",
     "Processing layer %@ of %@": "图层处理中... %@ \/ %@",
     "Advanced mode": "高级模式",
+    "Export layer influence rect": "导出图层的影响尺寸",
     "Set Name...": "设置名称...",
     "Import Colors": "导入颜色",
     "Export Colors": "导出颜色",

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/i18n/zh-Hant.json
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/i18n/zh-Hant.json
@@ -89,6 +89,7 @@
     "Import complete!": "匯入完畢",
     "Processing layer %@ of %@": "正在處理圖層... %@ \/ %@",
     "Advanced mode": "進階模式",
+    "Export layer influence rect": "匯出圖層的影響尺寸",
     "Set Name...": "設定名稱...",
     "Import Colors": "匯入色彩",
     "Export Colors": "匯出色彩",

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/panel/export.html
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/panel/export.html
@@ -246,6 +246,17 @@
                                     _('Advanced mode'),
                                 '</label>',
                             '</div>',
+                            //export influence rect
+                            '<div class="item">',
+                                '<label>',
+                                    '<div class="checkbox">',
+                                        '<input id="export-influence" type="checkbox" name="export-influence" value="0">',
+                                        '<label for="export-influence"></label>',
+                                    '</div>',
+                                    _('influence rect'),
+                                '</label>',
+                            '</div>',
+
                         '</div>',
                         '<div class="footer">',
                             '<button id="submit" class="submit" disabled="disabled">' + _('Export') + '</button>',

--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/panel/export.html
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/panel/export.html
@@ -246,14 +246,14 @@
                                     _('Advanced mode'),
                                 '</label>',
                             '</div>',
-                            //export influence rect
+                            //export influence rect option
                             '<div class="item">',
                                 '<label>',
                                     '<div class="checkbox">',
-                                        '<input id="export-influence" type="checkbox" name="export-influence" value="0">',
-                                        '<label for="export-influence"></label>',
+                                        '<input id="export-influenceRect" type="checkbox" name="export-influenceRect" value="0">',
+                                        '<label for="export-influenceRect"></label>',
                                     '</div>',
-                                    _('influence rect'),
+                                    _('Export layer influence rect'),
                                 '</label>',
                             '</div>',
 
@@ -311,6 +311,10 @@
 
             if(data.exportOption){
                 $('#export-option').attr('checked', true);
+            }
+
+            if(data.exportInfluenceRect){
+                $('#export-influenceRect').attr('checked', true);
             }
 
             $('.checkbutton')
@@ -387,6 +391,9 @@
                 });
                 data.exportOption = false;
                 if( $('input[name=export-option]:checked').length > 0 ) data.exportOption = true;
+
+                data.exportInfluenceRect = false;
+                if( $('input[name=export-influenceRect]:checked').length > 0 ) data.exportInfluenceRect = true;
 
                 data.order = $('input[name=order]:checked').val();
 


### PR DESCRIPTION
Add a feature :  Export layer's influence rect to Specs.
Layer's influence rect includes the area of shadows and outside borders, it's exactly the same size with the exported image. In most of time, shadows will not implement by engineers, it should be a part of image. Designer need to show the influence rect to engineers, not the regular rect. So I did this feature.

1. Add an option "Export layer influence rect" in Export UI. 
2. Use layer.absoluteInfluenceRect() in getLayer method.
3. Text layer is excluded.
4. i18n for Simple Chinese and Traditional Chinese.

ps: I changed the README.md and HOW-TO.md for fun, don't take it.  Sorry!
