### PR TITLE
Add support for native Sketch plugin updates

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/manifest.json
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/manifest.json
@@ -175,6 +175,7 @@
         "title" : "Sketch Measure"
     },
     "identifier": "com.utom.measure",
+    "appcast": "https://api.sketchpacks.com/v1/plugins/com.utom.measure/appcast",
     "homepage": "http://utom.design/measure/",
     "version": "2.6.3",
     "description" : "Make it a fun to create spec for developers and teammates",


### PR DESCRIPTION
This addition to the manifest allows for native Sketch plugin updates via [your Appcast feed](https://docs.sketchpacks.com/developers/publishing/providing-plugin-updates.html) served by Sketchpacks API.

You will also have access to Download and Update [plugin metrics](http://api.sketchpacks.com/v1/plugins/com.utom.measure) and [badges](https://docs.sketchpacks.com/developers/publishing/badges.html) for your `README.md`.

Resolves #318 