### PR TITLE
Update to common.js - Sketch 48 possible crash fix

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -641,14 +641,14 @@ SM.extend({
         if( style == false ){
             style = MSStyle.alloc().init();
 
-            var color = MSColor.colorWithRed_green_blue_alpha(color.r, color.g, color.b, color.a),
+            var color = MSImmutableColor.colorWithRed_green_blue_alpha(color.r, color.g, color.b, color.a),
                 fill = style.addStylePartOfType(0);
 
             fill.color = color;
 
             if(borderColor){
                 var border = style.addStylePartOfType(1),
-                    borderColor = MSColor.colorWithRed_green_blue_alpha(borderColor.r, borderColor.g, borderColor.b, borderColor.a);
+                    borderColor = MSImmutableColor.colorWithRed_green_blue_alpha(borderColor.r, borderColor.g, borderColor.b, borderColor.a);
 
                 border.color = borderColor;
                 border.thickness = 1;
@@ -667,7 +667,7 @@ SM.extend({
         style = (!style || this.is(style, MSSharedStyle))? style: style[0];
 
         if( style == false ){
-            var color = MSColor.colorWithRed_green_blue_alpha(color.r, color.g, color.b, color.a),
+            var color = MSImmutableColor.colorWithRed_green_blue_alpha(color.r, color.g, color.b, color.a),
                 alignment = alignment || 0, //[left, right, center, justify]
                 text = this.addText(this.page);
 
@@ -2669,7 +2669,7 @@ SM.extend({
                 ){
                     var textLayer = self.addText(),
                         colorRGB = self.hexToRgb(tData.fill || colorHex),
-                        color = MSColor.colorWithRed_green_blue_alpha(colorRGB.r / 255, colorRGB.g / 255, colorRGB.b / 255, (tData["fill-opacity"] || 1) );
+                        color = MSImmutableColor.colorWithRed_green_blue_alpha(colorRGB.r / 255, colorRGB.g / 255, colorRGB.b / 255, (tData["fill-opacity"] || 1) );
 
                     textLayer.setName(tData.content);
                     textLayer.setStringValue(tData.content);


### PR DESCRIPTION
Reference: https://gist.github.com/utom/a57a627b31cecbda4671e97ef80130e4

> var msLayer = context.selection[0]; // Select a text layer;
> var msColor = MSColor.colorWithRed_green_blue_alpha(1, 0.333333, 0, 1);
> log(msLayer);
> log(msColor);
> msLayer.setTextColor(msColor); // Sketch crashed!!

```
var msLayer = context.selection[0]; // Select a text layer;
var msColor = MSImmutableColor.colorWithRed_green_blue_alpha(1, 0.333333, 0, 1);
log(msLayer);
log(msColor);
msLayer.setTextColor(msColor); // Sketch won't crash!!!
```

