### PR TITLE
fix for issue 511 and 513

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -3103,6 +3103,14 @@ SM.extend({
         if(layer && this.is(layer, MSLayerGroup) && /NOTE\#/.exec(layer.name())){
             var textLayer = layer.children()[2];
 
+            var _i = 2;
+            while (!(textLayer instanceof MSTextLayer) && layer.children()[++_i]) {
+                textLayer = layer.children()[_i];
+            }
+            if (!(textLayer instanceof MSTextLayer)) {
+                textLayer = this.addText({}); // add example text
+            }
+
             data.notes.push({
                 rect: this.rectToJSON(textLayer.absoluteRect(), artboardRect),
                 note: this.toHTMLEncode(this.emojiToEntities(textLayer.stringValue())).replace(/\n/g, "<br>")


### PR DESCRIPTION
I found there are 4 items of `layer.children();`
![image](https://user-images.githubusercontent.com/1164959/48182824-a38f1500-e367-11e8-927a-07eee7ee27bc.png)

but `note` only add two layers in a container(MSLayerGroup) at common.js (line: 1965-1981)
I can't figure out.
hope someone can solve this

I just solve my friend's problem let her export successfully

thanks~