### PR TITLE
Delete the contents of the save directory before export

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -2885,6 +2885,9 @@ SM.extend({
                 savePath = this.getSavePath();
 
             if(savePath){
+                // Delete the files that are currently there to avoid building up cruft
+                NSFileManager.defaultManager().removeItemAtPath_error(savePath, nil);
+
                 // self.message(_("Exporting..."));
                 var processingPanel = this.SMPanel({
                         url: this.pluginSketch + "/panel/processing.html",


### PR DESCRIPTION
When exporting a spec repeatedly while tweaking assets for integration, the assets directory of the spec can become full of unwanted, old assets.

This pull request adds a cleanup step before each export where the save path is deleted recursively to keep the spec clean and representative of the actual assets in the latest version of the Sketch document.

This seems like a desirable default behaviour. I didn't notice a performance difference with or without the cleanup.

Please consider merging this into mainline!