### PR TITLE
fix export symbol with background

### DIFF
--- a/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
+++ b/Sketch Measure.sketchplugin/Contents/Sketch/library/common.js
@@ -2625,10 +2625,30 @@ SM.extend({
                     idx = 0;
 
                 overrides = (overrides)? overrides.objectForKey(0): undefined;
-
+                var hasSymbolBackgroud = symbolChildren.length < tempGroup.children().length;
+                
                 while(tempSymbolLayer = tempSymbolLayers.nextObject()){
+                    var symbolLayer = undefined;
+                    if (!hasSymbolBackgroud) {
+                        symbolLayer=symbolChildren[idx]
+                    } else {
+                        switch (idx) {
+                          case 0:
+                            symbolLayer = symbolChildren[0];
+                            break;
+                          case 1:
+                            symbolLayer = undefined;
+                            break;
+                          default:
+                            symbolLayer = symbolChildren[idx-1];
+                            break;
+                        }
+                    }
+                    // if(layer) console.log(tempSymbolLayer.name());
+                    // if(symbolLayer) console.log(symbolLayer.name());
+                    // console.log("====");
                     if( self.is(tempSymbolLayer, MSSymbolInstance) ){
-                        var symbolMasterObjectID = self.toJSString(symbolChildren[idx].objectID());
+                        var symbolMasterObjectID = self.toJSString(symbolLayer.objectID());
                         if(
                           overrides &&
                           overrides[symbolMasterObjectID] &&
@@ -2648,7 +2668,7 @@ SM.extend({
                           artboard,
                           tempSymbolLayer,
                           data,
-                          symbolChildren[idx]
+                          symbolLayer
                       );
                     }
                     idx++


### PR DESCRIPTION
This PR fix an issue which happens when user creates and uses a symbol, which with Backgroud & checked Include background in instances:

![image](https://user-images.githubusercontent.com/16953333/63826578-474abf80-c992-11e9-9f31-d47d56cd0b40.png)

This will create an extra rectangle with fill color of the background, for the detached instance, that's why the index always 1 more beyond the bounds.